### PR TITLE
Support `Mech2Result#getResponseBodyAsByteArray()`

### DIFF
--- a/src/main/java/me/geso/mech2/Mech2Result.java
+++ b/src/main/java/me/geso/mech2/Mech2Result.java
@@ -166,6 +166,16 @@ public class Mech2Result {
 	}
 
 	/**
+	 * Get the HTTP response as byte array.
+	 *
+	 * @return response body as byte array
+	 * @throws IOException
+	 */
+	public byte[] getResponseBodyAsByteArray() throws IOException {
+		return EntityUtils.toByteArray(this.response.getEntity());
+	}
+
+	/**
 	 * Shorthand for {@code mech.getResponse().getStatusLine().getStatusCode()}
 	 * 
 	 * @return status code.

--- a/src/test/java/me/geso/mech2/Mech2WithBaseTest.java
+++ b/src/test/java/me/geso/mech2/Mech2WithBaseTest.java
@@ -40,7 +40,7 @@ public class Mech2WithBaseTest {
 			Mech2WithBase wb = new Mech2WithBase(mech2, baseURI);
 			assertThat(wb.get("/").execute().getResponse().getStatusLine().getStatusCode(), is(200));
 			assertThat(wb.get("/").execute().getResponseBodyAsString(), is("HAHAHA"));
-			assertThat(wb.get("/").execute().getResponseBodyAsByteArray(), is("HAHAHA".getBytes()));
+			assertThat(wb.get("/").execute().getResponseBodyAsByteArray(), is("HAHAHA".getBytes(StandardCharsets.UTF_8)));
 		});
 
 	}

--- a/src/test/java/me/geso/mech2/Mech2WithBaseTest.java
+++ b/src/test/java/me/geso/mech2/Mech2WithBaseTest.java
@@ -40,6 +40,7 @@ public class Mech2WithBaseTest {
 			Mech2WithBase wb = new Mech2WithBase(mech2, baseURI);
 			assertThat(wb.get("/").execute().getResponse().getStatusLine().getStatusCode(), is(200));
 			assertThat(wb.get("/").execute().getResponseBodyAsString(), is("HAHAHA"));
+			assertThat(wb.get("/").execute().getResponseBodyAsByteArray(), is("HAHAHA".getBytes()));
 		});
 
 	}


### PR DESCRIPTION
For example, it is used when we need to proxy any binary files.